### PR TITLE
Added links and Python section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,4 +7,11 @@
 -   [Bell Schedule](https://www.pps.net/Page/6745)
 -   [Cleveland Calendar](https://www.pps.net/Page/320#calendar516)
 -   [Cleveland High School](https://www.pps.net/Domain/109)
+-   [Google Classroom](https://classroom.google.com/h)
+
+### Python 
+-   [Python w3schools Tutorial](https://www.w3schools.com/python/default.asp)
+-   [Processing Python Functions Reference](https://py.processing.org/reference/)
+
+
 


### PR DESCRIPTION
There was a python section in the last page. Do you still want it in this one? I added one with a link to the w3schools tutorial page and the processing python reference page. Also added google classroom to the school list. 