### PR TITLE
Added Naviance link under CHS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@
 -   [Cleveland Calendar](https://www.pps.net/Page/320#calendar516)
 -   [Cleveland High School](https://www.pps.net/Domain/109)
 -   [Google Classroom](https://classroom.google.com/h)
+-   [Naviance](https://student.naviance.com/cleveland)
 
 ### Python 
 -   [Python w3schools Tutorial](https://www.w3schools.com/python/default.asp)


### PR DESCRIPTION
The Naviance link for Cleveland is generally hard to find since the administration hides it in the main CHS website.  Seniors would appreciate having an easy place to find the link.