### PR TITLE
Updated Github Pull Request and Learning Lab

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,8 @@
 -   [Remove Background](https://www.remove.bg/){:target="_blank"}
  
 ### Github
--   [How to Create a Pull Request](https://services.github.com/on-demand/intro-to-github/create-pull-request){:target="_blank"}
+-   [How to Create a Pull Request](https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github){:target="_blank"}
+-   [GitHub Learning Lab](https://lab.github.com/){:target="_blank"}
 -   [Learn Git Branching](https://learngitbranching.js.org/){:target="_blank"}
 -   [How to use Git and Github Video Tutorials](https://www.youtube.com/playlist?list=PLRqwX-V7Uu6ZF9C0YMKuns9sLDzK6zoiV){:target="_blank"}
 -   [Google Launchpad Accelerators](https://developers.google.com/programs/launchpad/accelerators/){:target="_blank"}


### PR DESCRIPTION
The old pull request tutorial redirected to the Learning Lab. Hacktoberfest has a new tutorial for pull requests. I added a new line for the Learning Lab so it is still accessible.